### PR TITLE
Remove sudo from docker commands

### DIFF
--- a/source/hardware_inventory_management.rst
+++ b/source/hardware_inventory_management.rst
@@ -167,7 +167,7 @@ For example, to put |hypervisor_hostname| into maintenance:
 .. code-block:: console
    :substitutions:
 
-   seed# sudo docker exec -it bifrost_deploy /bin/bash
+   seed# docker exec -it bifrost_deploy /bin/bash
    (bifrost-deploy)[root@seed bifrost-base]# OS_CLOUD=bifrost openstack baremetal node maintenance set |hypervisor_hostname|
 
 .. ifconfig:: deployment['ceph_managed']
@@ -184,7 +184,7 @@ For example, to take |hypervisor_hostname| out of maintenance:
 .. code-block:: console
    :substitutions:
 
-   seed# sudo docker exec -it bifrost_deploy /bin/bash
+   seed# docker exec -it bifrost_deploy /bin/bash
    (bifrost-deploy)[root@seed bifrost-base]# OS_CLOUD=bifrost openstack baremetal node maintenance unset |hypervisor_hostname|
 
 Detect hardware differences with cardiff

--- a/source/introduction.rst
+++ b/source/introduction.rst
@@ -49,7 +49,8 @@ variables conventionally drawn from ``kayobe-config/kayobe-env``. The
 
 ``seed#``
 
-A command that must be run on the seed VM.
+A command that must be run on the seed VM using the Kayobe Ansible user account
+(``stack`` by default).
 
 ``bifrost#``
 

--- a/source/working_with_kayobe.rst
+++ b/source/working_with_kayobe.rst
@@ -136,7 +136,7 @@ user account on the seed is the |seed_user| user.
    :substitutions:
 
    kayobe# ssh -l stack |seed_ip|
-   [stack@seed ~]$ sudo docker ps
+   seed# docker ps
    CONTAINER ID        IMAGE               COMMAND                  CREATED             STATUS              PORTS                    NAMES
    ed034742903b        registry:latest     "/entrypoint.sh /etc…"   2 months ago        Up 2 months         0.0.0.0:5000->5000/tcp   docker_registry
    640221d53b0f        9355cba4a8cd        "/sbin/init"             2 months ago        Up 2 months                                  bifrost_deploy
@@ -150,7 +150,7 @@ From the seed host, the Bifrost container may be entered:
 
 .. code-block:: console
 
-   seed# sudo docker exec -it bifrost_deploy /bin/bash
+   seed# docker exec -it bifrost_deploy /bin/bash
    (bifrost-deploy)[root@seed bifrost-base]# source env-vars
    (bifrost-deploy)[root@seed bifrost-base]# openstack baremetal node list
 


### PR DESCRIPTION
Using sudo is unecessary when using the Kayobe Ansible user.
