### PR TITLE
update kayobe docs

### DIFF
--- a/source/working_with_kayobe.rst
+++ b/source/working_with_kayobe.rst
@@ -13,6 +13,9 @@ Kayobe is open source and can be downloaded from the Git repository
 |kayobe_source_url| (use the |kayobe_source_version| branch).
 
 Kayobe's online documentation is available here:
+https://docs.openstack.org/kayobe/latest/
+
+Documentation of stackhpc-kayobe-config can be found here:
 https://stackhpc-kayobe-config.readthedocs.io/en/stackhpc-2025.1/operations/index.html
 
 The infrastructure-as-code configuration state for the |project_name| OpenStack

--- a/source/working_with_kayobe.rst
+++ b/source/working_with_kayobe.rst
@@ -13,7 +13,7 @@ Kayobe is open source and can be downloaded from the Git repository
 |kayobe_source_url| (use the |kayobe_source_version| branch).
 
 Kayobe's online documentation is available here:
-https://docs.openstack.org/kayobe/latest/
+https://stackhpc-kayobe-config.readthedocs.io/en/stackhpc-2025.1/operations/index.html
 
 The infrastructure-as-code configuration state for the |project_name| OpenStack
 is here: |kayobe_config_source_url| (use the |kayobe_config_source_version|


### PR DESCRIPTION
Update link to main Kayobe docs to: https://stackhpc-kayobe-config.readthedocs.io/en/stackhpc-2025.1/operations/index.html